### PR TITLE
Set variables if cwdiswppslinter is true

### DIFF
--- a/install-script-dependencies.sh
+++ b/install-script-dependencies.sh
@@ -1,9 +1,21 @@
 #!/bin/bash
 
+while getopts 'c:' flag; do
+	case "${flag}" in
+		c) cwdiswppslinter=${OPTARG} ;;
+	esac
+done
+
 # Get the absolute path to the plugin we want to check.
-plugindir="$(dirname "$(dirname "$(realpath "$0")" )" )"
-wpcontentdir="$(dirname "$(dirname "$(dirname "$(dirname "$(realpath $0)" )" )" )" )"
-scriptsdir="$plugindir/wpps-scripts/"
+if [ "$cwdiswppslinter" = "1" ]; then
+	plugindir="$(dirname "$(dirname "$(dirname "$(dirname "$(realpath "$0")" )" )" )" )/$plugindirname"
+	wpcontentdir="./../../../../"
+	scriptsdir="$(dirname "$(realpath "$0")" )/"
+else
+	plugindir="$(dirname "$(dirname "$(realpath "$0")" )" )"
+	wpcontentdir="$(dirname "$(dirname "$(dirname "$(dirname "$(realpath $0)" )" )" )" )"
+	scriptsdir="$plugindir/wpps-scripts/"
+fi
 
 #Go to wp-content directory.
 cd "$wpcontentdir";

--- a/lint-css.sh
+++ b/lint-css.sh
@@ -12,9 +12,9 @@ done
 
 # Get the absolute path to the plugin we want to check.
 if [ "$cwdiswppslinter" = "1" ]; then
-	plugindir="$(dirname $(dirname $(dirname $(dirname $(realpath $0) ) ) ) )/$plugindirname"
+	plugindir="$(dirname "$(dirname "$(dirname "$(dirname "$(realpath "$0")" )" )" )" )/$plugindirname"
 	wpcontentdir="./../../../../"
-	scriptsdir="$(dirname $(realpath $0) ) )"
+	scriptsdir="$(dirname "$(realpath "$0")" )/"
 else
 	plugindir="$(dirname "$(dirname "$(realpath "$0")" )" )"
 	wpcontentdir="$(dirname "$(dirname "$(dirname "$(dirname "$(realpath $0)" )" )" )" )"
@@ -23,7 +23,7 @@ fi
 
 #Go to wp-content directory.
 cd "$wpcontentdir";
-sh "${scriptsdir}/install-script-dependencies.sh"
+sh "${scriptsdir}/install-script-dependencies.sh" -c $cwdiswppslinter
 
 # Run the lint command from the wp-content directory.
 if [ "$fix" = "1" ]; then

--- a/lint-js.sh
+++ b/lint-js.sh
@@ -12,9 +12,9 @@ done
 
 # Get the absolute path to the plugin we want to check.
 if [ "$cwdiswppslinter" = "1" ]; then
-	plugindir="$(dirname $(dirname $(dirname $(dirname $(realpath $0) ) ) ) )/$plugindirname"
+	plugindir="$(dirname "$(dirname "$(dirname "$(dirname "$(realpath "$0")" )" )" )" )/$plugindirname"
 	wpcontentdir="./../../../../"
-	scriptsdir="$(dirname $(realpath $0) ) )"
+	scriptsdir="$(dirname "$(realpath "$0")" )/"
 else
 	plugindir="$(dirname "$(dirname "$(realpath "$0")" )" )"
 	wpcontentdir="$(dirname "$(dirname "$(dirname "$(dirname "$(realpath $0)" )" )" )" )"
@@ -23,7 +23,7 @@ fi
 
 #Go to wp-content directory.
 cd "$wpcontentdir";
-sh "${scriptsdir}/install-script-dependencies.sh"
+sh "${scriptsdir}/install-script-dependencies.sh" -c $cwdiswppslinter
 
 # Run the lint command from the wp-content directory.
 if [ "$fix" = "1" ]; then

--- a/phpcs.sh
+++ b/phpcs.sh
@@ -10,9 +10,9 @@ done
 
 # Get the absolute path to the plugin we want to check.
 if [ "$cwdiswppslinter" = "1" ]; then
-	plugindir="$(dirname $(dirname $(dirname $(dirname $(realpath $0) ) ) ) )/$plugindirname"
+	plugindir="$(dirname "$(dirname "$(dirname "$(dirname "$(realpath "$0")" )" )" )" )/$plugindirname"
 	wpcontentdir="./../../../../"
-	scriptsdir="$(dirname $(realpath $0) ) )"
+	scriptsdir="$(dirname "$(realpath "$0")" )/"
 else
 	plugindir="$(dirname "$(dirname "$(realpath "$0")" )" )"
 	wpcontentdir="$(dirname "$(dirname "$(dirname "$(dirname "$(realpath $0)" )" )" )" )"
@@ -21,22 +21,10 @@ fi
 
 #Go to wp-content directory.
 cd "$wpcontentdir";
-
-# Make sure that packagejson and composer json exist in wp-content.
-if [ ! -f package.json ] || [ ! -f composer.json ]; then
-	cd "$scriptsdir";
-	sh hoister.sh -c "$wpcontentdir";
-	cd "$wpcontentdir";
-fi
-
-# Make sure that vendor exists in wp-content.
-if [ ! -d vendor ]; then
-	# Run composer install in wp-content
-	composer install;
-fi
+sh "${scriptsdir}/install-script-dependencies.sh" -c $cwdiswppslinter
 
 # Copy the phpcs.xml file from the wpps-scripts module to wp-content.
-cp "$scriptsdir"/phpcs.xml ./
+cp "$scriptsdir"phpcs.xml ./
 
 # Modify the phpcs.xml file in the wpps-scripts module to contain the namespace and text domain of the plugin in question.
 sed -i.bak "s/MadeWithWPPS/$namespace/g" phpcs.xml

--- a/phpunit.sh
+++ b/phpunit.sh
@@ -8,9 +8,9 @@ done
 
 # Get the absolute path to the plugin we want to check.
 if [ "$cwdiswppslinter" = "1" ]; then
-	plugindir="$(dirname $(dirname $(dirname $(dirname $(realpath $0) ) ) ) )/$plugindirname"
+	plugindir="$(dirname "$(dirname "$(dirname "$(dirname "$(realpath "$0")" )" )" )" )/$plugindirname"
 	wpcontentdir="./../../../../"
-	scriptsdir="$(dirname $(realpath $0) ) )"
+	scriptsdir="$(dirname "$(realpath "$0")" )/"
 else
 	plugindir="$(dirname "$(dirname "$(realpath "$0")" )" )"
 	wpcontentdir="$(dirname "$(dirname "$(dirname "$(dirname "$(realpath $0)" )" )" )" )"
@@ -19,25 +19,7 @@ fi
 
 #Go to wp-content directory.
 cd "$wpcontentdir";
-
-# Make sure that packagejson and composer json exist in wp-content.
-if [ ! -f package.json ] || [ ! -f composer.json ]; then
-	cd "$scriptsdir";
-	sh hoister.sh -c "$wpcontentdir";
-	cd "$wpcontentdir";
-fi
-
-# Make sure that node_modules exists in wp-content.
-if [ ! -d node_modules ]; then
-	# Run npm install in wp-content
-	npm install;
-fi
-
-# Make sure that vendor exists in wp-content.
-if [ ! -d vendor ]; then
-	# Run composer install in wp-content
-	composer install;
-fi
+sh "${scriptsdir}/install-script-dependencies.sh" -c $cwdiswppslinter
 
 # Start wp-env
 npx -p @wordpress/env wp-env start

--- a/test-js.sh
+++ b/test-js.sh
@@ -1,10 +1,23 @@
 #!/bin/bash
 
-plugindir="$(dirname "$(dirname "$(realpath "$0")" )" )"
-wpcontentdir="$(dirname "$(dirname "$(dirname "$(dirname "$(realpath $0)" )" )" )" )"
-scriptsdir="${plugindir}/wpps-scripts/"
+while getopts 'p:' flag; do
+	case "${flag}" in
+		p) plugindirname=${OPTARG} ;;
+	esac
+done
+
+# Get the absolute path to the plugin we want to check.
+if [ "$cwdiswppslinter" = "1" ]; then
+	plugindir="$(dirname "$(dirname "$(dirname "$(dirname "$(realpath "$0")" )" )" )" )/$plugindirname"
+	wpcontentdir="./../../../../"
+	scriptsdir="$(dirname "$(realpath "$0")" )/"
+else
+	plugindir="$(dirname "$(dirname "$(realpath "$0")" )" )"
+	wpcontentdir="$(dirname "$(dirname "$(dirname "$(dirname "$(realpath $0)" )" )" )" )"
+	scriptsdir="$plugindir/wpps-scripts/"
+fi
 
 cd "$wpcontentdir"
-sh "${scriptsdir}/install-script-dependencies.sh"
+sh "${scriptsdir}/install-script-dependencies.sh" -c $cwdiswppslinter
 
 npm run test:js $plugindir


### PR DESCRIPTION
This PR makes it so that `cwdiswppslinter` is true when passed to scripts, it defines variables accordingly. 

The reason this exists is because in [wp-plugin-sidekick](https://github.com/wp-plugin-sidekick/wp-plugin-sidekick), you can run these linters even if a plugin doesn't have `wpps-scripts` set up.

In fact, a plugin doesn't even need a package.json file in order to be linted with `wp-plugin-sidekick`. 

Of course [this repo](https://github.com/wp-plugin-sidekick/wpps-scripts) exists to make it so that you can easily have your own included package.json file, and you don't require wp-plugin-sidekick. 

So the `cwdiswppslinter` and subsequent `if checks` exist so that this repo, and the module in wp-plugin-sidekick can match exactly. 

This might not stay this way forever, but for now this works. 

Here's a screenshot to help show how it works in wp-plugin-sidekick and why `cwdiswppslinter` is needed.
<img width="1764" alt="Screen Shot 2022-03-22 at 3 02 16 PM" src="https://user-images.githubusercontent.com/7538525/159556777-18e4b6a6-61a4-4f3d-bec6-0af0764088bd.png">

