### PR TITLE
Show a message if the `realpath` command doesn't exist

### DIFF
--- a/install-script-dependencies.sh
+++ b/install-script-dependencies.sh
@@ -8,6 +8,7 @@ done
 
 if ! command -v realpath &> /dev/null; then
 	echo "The realpath command was not found, if you're on macOS, you may need to do 'brew install coreutils'"
+	exit 1
 fi
 
 # Get the absolute path to the plugin we want to check.

--- a/install-script-dependencies.sh
+++ b/install-script-dependencies.sh
@@ -8,6 +8,7 @@ done
 
 if [ ! "$(realpath "$0")" ]; then
 	echo "The realpath command might not exist. If you're on macOS, you may need to do 'brew install coreutils'"
+	exit 1
 fi
 
 # Get the absolute path to the plugin we want to check.

--- a/install-script-dependencies.sh
+++ b/install-script-dependencies.sh
@@ -6,7 +6,7 @@ while getopts 'c:' flag; do
 	esac
 done
 
-if ! command -v realpath &> /dev/null; then
+if [ ! $(command -v realpath &> /dev/null) ]; then
 	echo "The realpath command was not found, if you're on macOS, you may need to do 'brew install coreutils'"
 	exit 1
 fi

--- a/install-script-dependencies.sh
+++ b/install-script-dependencies.sh
@@ -6,6 +6,10 @@ while getopts 'c:' flag; do
 	esac
 done
 
+if ! command -v realpath &> /dev/null; then
+	echo "The realpath command was not found, if you're on macOS, you may need to do 'brew install coreutils'"
+fi
+
 # Get the absolute path to the plugin we want to check.
 if [ "$cwdiswppslinter" = "1" ]; then
 	plugindir="$(dirname "$(dirname "$(dirname "$(dirname "$(realpath "$0")" )" )" )" )/$plugindirname"

--- a/install-script-dependencies.sh
+++ b/install-script-dependencies.sh
@@ -6,9 +6,8 @@ while getopts 'c:' flag; do
 	esac
 done
 
-if [ ! $(command -v realpath &> /dev/null) ]; then
-	echo "The realpath command was not found, if you're on macOS, you may need to do 'brew install coreutils'"
-	exit 1
+if [ ! "$(realpath "$0")" ]; then
+	echo "The realpath command might not exist. If you're on macOS, you may need to do 'brew install coreutils'"
 fi
 
 # Get the absolute path to the plugin we want to check.


### PR DESCRIPTION
* Shows a message if the `realpath` command doesn't exist
* See this PR in action: https://github.com/studiopress/fse-studio/pull/77 