### PR TITLE
Fix phpcbf

### DIFF
--- a/phpcs.sh
+++ b/phpcs.sh
@@ -12,7 +12,7 @@ sed -i.bak "s/madewithwpps/$textdomain/g" phpcs.xml
 
 # Run the phpcs command from the wp-content directory.
 if [ "$fix" = "1" ]; then
-	./vendor/bin/phpcbf -q "$plugindir";
+	./vendor/bin/phpcbf -q "$plugindir" --basepath="$wpcontentdir"
 	./vendor/bin/phpcs -q "$plugindir";
 else
 	./vendor/bin/phpcs -q "$plugindir";

--- a/setup.sh
+++ b/setup.sh
@@ -15,7 +15,8 @@ if [ ! "$(realpath "$0")" ]; then
 fi
 
 # Define the absolute path to the plugin we want to deal with.
-plugindir="$(dirname "$(dirname "$(realpath "$0")" )" )"/plugins/$plugindirname
+wpcontentdir="$(dirname "$(dirname "$(realpath "$0")" )" )"
+plugindir=$wpcontentdir/plugins/$plugindirname
 
 # Install dependencies.
 if [ ! -d node_modules ] || [ ! -d vendor ]; then


### PR DESCRIPTION
In the re-structure phpcbf (lint fixing for PHP) was broken because of this:
https://github.com/squizlabs/PHP_CodeSniffer/issues/2599

This PR fixes that by passing the wp-content directory as the basename. It should now work to run `npm run lint:php:fix` in fse-studio.