### PR TITLE
Fix zipping after re-structure

### DIFF
--- a/zip.sh
+++ b/zip.sh
@@ -3,16 +3,16 @@
 # Run setup.
 . ./setup.sh
 
-plugin_slug="$(basename "$plugin_dir")"
+plugin_slug="$(basename "$plugindir")"
 
-build_version=`grep 'Version:' $plugin_dir/$plugin_slug.php | cut -f4 -d' '`
+build_version=`grep 'Version:' $plugindir/$plugin_slug.php | cut -f4 -d' '`
 zip_file_name="$plugin_slug.$build_version.zip"
-cd "$(dirname "$plugin_dir")"
+cd "$(dirname "$plugindir")"
 
-if [ ! -f "$plugin_dir/.zipignore" ]; then
+if [ ! -f "$plugindir/.zipignore" ]; then
 	echo "Error: please add a .zipignore to the root of the plugin"
 	exit 1
 fi
 
-zip -r "$zip_file_name" "$plugin_slug" -x@"$plugin_dir/.zipignore"
-mv "$zip_file_name" "$plugin_dir"
+zip -r "$zip_file_name" "$plugin_slug" -x@"$plugindir/.zipignore"
+mv "$zip_file_name" "$plugindir"


### PR DESCRIPTION
Zipping was broken because we now pull the name from step.sh, which doesn't use underscores when defining plugindir. This fixes it. 