### PR TITLE
Stop using realpath

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -9,13 +9,8 @@ while getopts 'p:n:t:f:' flag; do
 	esac
 done
 
-if [ ! "$(realpath "$0")" ]; then
-	echo "The realpath command might not exist. If you're on macOS, you may need to do 'brew install coreutils'"
-	exit 1
-fi
-
 # Define the absolute path to the plugin we want to deal with.
-wpcontentdir="$(dirname "$(dirname "$(realpath "$0")" )" )"
+wpcontentdir="$(dirname "${PWD:A}" )"
 plugindir=$wpcontentdir/plugins/$plugindirname
 
 # Install dependencies.


### PR DESCRIPTION
This PR removes the use of realpath. A lot of our team was getting an error that it was missing. It seems it may not be necessary. 

See: https://github.com/wp-plugin-sidekick/wpps-scripts/issues/13