### PR TITLE
Use PWD but override if realpath exists

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -9,8 +9,15 @@ while getopts 'p:n:t:f:' flag; do
 	esac
 done
 
+# Get the absolute path to wpcontent
+wpcontentdir="$(dirname "$PWD" )"
+
+# If this system supports realpath, override with that.
+if [ "$(realpath "$0")" ]; then
+	wpcontentdir="$(dirname "$(dirname "$(realpath "$0")" )" )"
+fi
+
 # Define the absolute path to the plugin we want to deal with.
-wpcontentdir="$(dirname "${PWD:A}" )"
 plugindir=$wpcontentdir/plugins/$plugindirname
 
 # Install dependencies.


### PR DESCRIPTION
It looks like the version of shell/bash on circleci doesn't support the syntax we used in https://github.com/wp-plugin-sidekick/wpps-scripts/pull/14

See:
https://app.circleci.com/pipelines/github/studiopress/fse-studio/543/workflows/3c25f596-31de-41f8-ab00-e8db576576f3/jobs/1201?invite=true#step-108-7

For now I am going to use PWD with a fallback to realpath if it is available. We can adjust later if needed. 