### PR TITLE
Fix setup & zip $plugindir

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -27,7 +27,7 @@ if [ ! -d node_modules ] || [ ! -d vendor ]; then
 fi
 
 # Loop through each wp-module in the plugin, and install their dependencies.
-for DIR in $plugindir/wp-modules/*; do
+for DIR in "$plugindir"/wp-modules/*; do
 	# If this module has a package.json file.
 	if [ -f "$DIR/package.json" ]; then
 		# Go to the directory of this wp-module.

--- a/zip.sh
+++ b/zip.sh
@@ -5,7 +5,7 @@
 
 plugin_slug="$(basename "$plugindir")"
 
-build_version=`grep 'Version:' $plugindir/$plugin_slug.php | cut -f4 -d' '`
+build_version=`grep 'Version:' "$plugindir"/$plugin_slug.php | cut -f4 -d' '`
 zip_file_name="$plugin_slug.$build_version.zip"
 cd "$(dirname "$plugindir")"
 


### PR DESCRIPTION
Fixes issues I had with `wpps-scripts` when setting up tippy.

Zip would run, but didn't append the version (I didn't check the files).

<img width="156" alt="Screen Shot 2022-04-05 at 2 03 17 PM" src="https://user-images.githubusercontent.com/1271053/161820756-a943f74c-f097-43fd-afb6-b2eb3d3428e5.png">
 