### PR TITLE
Ensure quotes around $plugindir

### DIFF
--- a/lint-css.sh
+++ b/lint-css.sh
@@ -5,7 +5,7 @@
 
 # Run the lint command from the wp-content directory.
 if [ "$fix" = "1" ]; then
-	npm run lint:css "$plugindir/**/css/src/*.*css"  -- --fix;
+	npm run lint:css "$plugindir"/**/css/src/*.*css  -- --fix;
 else
-	npm run lint:css "$plugindir/**/css/src/*.*css";
+	npm run lint:css "$plugindir"/**/css/src/*.*css;
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -18,7 +18,7 @@ if [ "$(realpath "$0")" ]; then
 fi
 
 # Define the absolute path to the plugin we want to deal with.
-plugindir=$wpcontentdir/plugins/$plugindirname
+plugindir="$wpcontentdir"/plugins/"$plugindirname"
 
 # Install dependencies.
 if [ ! -d node_modules ] || [ ! -d vendor ]; then
@@ -29,7 +29,7 @@ fi
 # Loop through each wp-module in the plugin, and install their dependencies.
 for DIR in "$plugindir"/wp-modules/*; do
 	# If this module has a package.json file.
-	if [ -f "$DIR/package.json" ]; then
+	if [ -f "$DIR"/package.json ]; then
 		# Go to the directory of this wp-module.
 		cd "$DIR";
 

--- a/test-js.sh
+++ b/test-js.sh
@@ -3,4 +3,4 @@
 # Run setup.
 . ./setup.sh
 
-npm run test:js -- --roots $plugindir
+npm run test:js -- --roots "$plugindir"


### PR DESCRIPTION
This PR makes sure that quotes are used around variables containing a full filepath. I think this catches any left.