### PR TITLE
Make it so that multiple modules can have builds that get run

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -12,11 +12,11 @@ for DIR in "$plugindir"/wp-modules/*; do
 		cd "$DIR";
 		
 		if [ ! -d node_modules ]; then
-			npm install;
+			npm install &
 		fi
 
 		# Run the build script for this module.
-		npm run dev;
+		npm run dev &
 	fi
 
 done


### PR DESCRIPTION
This makes it so that you can have multiple modules in a single plugin running `npm run dev` at the same time.