### PR TITLE
Ensure correct-node-version

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -9,6 +9,13 @@ while getopts 'p:n:t:f:' flag; do
 	esac
 done
 
+# Make sure the node version matches.
+nodeversion=$( node -v );
+if [[ $nodeversion != v14* ]]; then
+	echo "Your version of node needs to be v14, but it is set to be "$nodeversion;
+	exit 1;
+fi
+
 # Get the absolute path to wpcontent
 wpcontentdir="$(dirname "$PWD" )"
 


### PR DESCRIPTION
This PR makes it so that the setup.sh script checks to make sure the node version is correct for the project before continuing. 