### PR TITLE
Pin `@wordpress/scripts` to exact version, don't allow bumping patch or minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
 		"@wordpress/env": "^4.3.1",
 		"@wordpress/eslint-plugin": "^12.4.0",
 		"@wordpress/jest-preset-default": "^8.1.1",
-		"@wordpress/scripts": "23.2.0"
+		"@wordpress/scripts": "23.3.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
 		"@wordpress/env": "^4.3.1",
 		"@wordpress/eslint-plugin": "^12.4.0",
 		"@wordpress/jest-preset-default": "^8.1.1",
-		"@wordpress/scripts": "^23.2.0"
+		"@wordpress/scripts": "23.2.0"
 	}
 }


### PR DESCRIPTION
## What does this do?
* Pin `@wordpress/scripts` to exact version, don't allow bumping patch or minor version
* Bump it to the latest
* A less drastic approach than https://github.com/wp-plugin-sidekick/wpps-scripts/pull/22

## Background
As Phil mentioned, linting via `wpps-scripts` can have different results locally and in CI/CD.

This looks to be from different versions of `@wordpress/scripts` and/or `prettier` rules.

We'd like to make this more consistent.