### PR TITLE
Bump `@wordpress/scripts` to the next major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
 		"@wordpress/env": "^4.3.1",
 		"@wordpress/eslint-plugin": "^12.4.0",
 		"@wordpress/jest-preset-default": "^8.1.1",
-		"@wordpress/scripts": "23.3.0"
+		"@wordpress/scripts": "24.0.0"
 	}
 }


### PR DESCRIPTION
In response to eslint failing on the FSE Studio [alphaV3 branch](https://github.com/studiopress/fse-studio/tree/fd0efeffdd124badb97478e2b72f84e29e2bda3d) with:
```
Unknown property 'key' found react/no-unknown-property
```

This PR seems to have fixed most of those errors.

https://github.com/studiopress/fse-studio/pull/186 is running this branch