### PR TITLE
Set `jsx-no-target-blank` to `off`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,5 +14,8 @@
     "jsdoc": {
       "mode": "typescript"
     }
+  },
+  "rules": {
+    "react/jsx-no-target-blank": "off"
   }
 }


### PR DESCRIPTION
A security risk error is thrown for links with `target="_blank"` if `noopener` is used without `noreferrer`. However, this is not necessary in modern browsers.