### PR TITLE
Add TypeScript extensions for module imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,12 @@
   "settings": {
     "jsdoc": {
       "mode": "typescript"
-    }
+    },
+    "import/resolver": {
+      "node": {
+        "extensions": [".js", ".jsx", ".ts", ".tsx"]
+      }
+    },
   },
   "rules": {
     "react/jsx-no-target-blank": "off"


### PR DESCRIPTION
Right now, linting errors are shown for TS module resolution (even with successful module imports). This simply adds TS file extensions to correct the linting error.