### PR TITLE
Disable eslint rules that don't apply to TypeScript

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,9 +21,18 @@
     }
   },
   "rules": {
-    "jsdoc/require-param": "off",
-    "jsdoc/require-param-type": "off",
-    "jsdoc/require-returns-type": "off",
     "react/jsx-no-target-blank": "off"
-  }
+  },
+  "overrides": [
+    {
+      "files": [ "*.ts", "*.tsx" ],
+      "rules": {
+        "jsdoc/require-param": "off",
+        "jsdoc/require-param-type": "off",
+        "jsdoc/require-returns-type": "off",
+        "no-unused-vars": "off",
+        "no-undef": "off"
+      }
+    }
+  ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -18,9 +18,11 @@
       "node": {
         "extensions": [".js", ".jsx", ".ts", ".tsx"]
       }
-    },
+    }
   },
   "rules": {
+    "jsdoc/require-param-type": "off",
+    "jsdoc/require-returns-type": "off",
     "react/jsx-no-target-blank": "off"
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,7 @@
     }
   },
   "rules": {
+    "jsdoc/require-param": "off",
     "jsdoc/require-param-type": "off",
     "jsdoc/require-returns-type": "off",
     "react/jsx-no-target-blank": "off"


### PR DESCRIPTION
In TypeScript, we don't always need JSDoc `@param` and `@return` tags. 

We can have them when we want, but no need to require them with `eslint`.

## Testing instructions
Ensure CI/CD is passing on https://github.com/studiopress/fse-studio/pull/258