### PR TITLE
Move disabled to the `overrides` property

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,8 +21,6 @@
     }
   },
   "rules": {
-    "jsdoc/require-param-type": "off",
-    "jsdoc/require-returns-type": "off",
     "react/jsx-no-target-blank": "off"
   },
   "overrides": [

--- a/.eslintrc
+++ b/.eslintrc
@@ -18,9 +18,11 @@
       "node": {
         "extensions": [".js", ".jsx", ".ts", ".tsx"]
       }
-    },
+    }
   },
   "rules": {
+    "jsdoc/require-param-type": "off",
+    "jsdoc/require-returns-type": "off",
     "react/jsx-no-target-blank": "off"
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -24,5 +24,17 @@
     "jsdoc/require-param-type": "off",
     "jsdoc/require-returns-type": "off",
     "react/jsx-no-target-blank": "off"
-  }
+  },
+  "overrides": [
+    {
+      "files": [ "*.ts", "*.tsx" ],
+      "rules": {
+        "jsdoc/require-param": "off",
+        "jsdoc/require-param-type": "off",
+        "jsdoc/require-returns-type": "off",
+        "no-unused-vars": "off",
+        "no-undef": "off"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
* Copies Gutenberg's [overrides for TypeScript](https://github.com/WordPress/gutenberg/blob/fd1c67285aac00526155947a424722fbe13086d9/packages/eslint-plugin/configs/recommended.js#L42-L58)
* TypeScript has different linting needs
* This means we don't need [comments like these](https://github.com/studiopress/fse-studio/pull/259/files#r1049019138)

## Testing instructions
Ensure CircleCI passes on https://github.com/studiopress/fse-studio/pull/258 (that PR is running this PR)