### PR TITLE
Check plugin for eslintrc file, and use it if it exists

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -16,7 +16,7 @@ for DIR in "$plugindir"/wp-modules/*; do
 		fi
 
 		# Run the build script for this module.
-		npm ci && npm run dev &
+		npm run dev &
 	fi
 
 done

--- a/dev.sh
+++ b/dev.sh
@@ -16,7 +16,7 @@ for DIR in "$plugindir"/wp-modules/*; do
 		fi
 
 		# Run the build script for this module.
-		npm run dev &
+		npm ci && npm run dev &
 	fi
 
 done

--- a/lint-js.sh
+++ b/lint-js.sh
@@ -3,9 +3,19 @@
 # Run setup.
 . ./setup.sh
 
-# Run the lint command from the wp-content directory.
-if [ "$fix" = "1" ]; then
-	npm run lint:js "$plugindir" -- --config .eslintrc --fix;
-else
-	npm run lint:js "$plugindir" -- --config .eslintrc;
+# Check if there is an .eslintrc file in this project. If so, use it for standards. Otherwise,
+if [ -f "$plugindir/.eslintrc" ];
+then
+	if [ "$fix" = "1" ]; then
+		npm run lint:js "$plugindir" -- --config $plugindir/.eslintrc --fix;
+	else
+		npm run lint:js "$plugindir" -- --config $plugindir/.eslintrc;
+	fi
+else 
+	# Run the lint command from the wp-content directory.
+	if [ "$fix" = "1" ]; then
+		npm run lint:js "$plugindir" -- --fix;
+	else
+		npm run lint:js "$plugindir";
+	fi
 fi

--- a/lint-js.sh
+++ b/lint-js.sh
@@ -12,10 +12,9 @@ then
 		npm run lint:js "$plugindir" -- --config $plugindir/.eslintrc;
 	fi
 else 
-	# Run the lint command from the wp-content directory.
 	if [ "$fix" = "1" ]; then
-		npm run lint:js "$plugindir" -- --fix;
+		npm run lint:js "$plugindir" -- --config .eslintrc --fix;
 	else
-		npm run lint:js "$plugindir";
+		npm run lint:js "$plugindir" -- --config .eslintrc;
 	fi
 fi


### PR DESCRIPTION
If a plugin contains its own .eslintrc standard file, use it instead of the built-in one in wpps-scripts.