### PR TITLE
Also allow a `.distignore` file for zipping

### DIFF
--- a/zip.sh
+++ b/zip.sh
@@ -11,7 +11,7 @@ cd "$(dirname "$plugindir")"
 
 if [ -f "$plugindir/.zipignore" ]; then
 	ignore_file="$plugindir/.zipignore"
-else if [ -f "$plugindir/.distignore" ]; then
+elif [ -f "$plugindir/.distignore" ]; then
 	ignore_file="$plugindir/.distignore"
 else
 	echo "Error: please add a .zipignore to the root of the plugin"

--- a/zip.sh
+++ b/zip.sh
@@ -9,10 +9,14 @@ build_version=`grep 'Version:' "$plugindir"/$plugin_slug.php | cut -f4 -d' '`
 zip_file_name="$plugin_slug.$build_version.zip"
 cd "$(dirname "$plugindir")"
 
-if [ ! -f "$plugindir/.zipignore" ]; then
+if [ -f "$plugindir/.zipignore" ]; then
+	ignore_file="$plugindir/.zipignore"
+else if [ -f "$plugindir/.distignore" ]; then
+	ignore_file="$plugindir/.distignore"
+else
 	echo "Error: please add a .zipignore to the root of the plugin"
 	exit 1
 fi
 
-zip -r "$zip_file_name" "$plugin_slug" -x@"$plugindir/.zipignore"
+zip -r "$zip_file_name" "$plugin_slug" -x@"$ignore_file"
 mv "$zip_file_name" "$plugindir"


### PR DESCRIPTION
* Prevents having a `.zipignore` and `.svnignore` in the same repo
* Instead, just have a single `.distignore` for both