### PR TITLE
Ensure zip ignore file begins and ends with `*`

### DIFF
--- a/zip.sh
+++ b/zip.sh
@@ -9,10 +9,12 @@ build_version=`grep 'Version:' "$plugindir"/$plugin_slug.php | cut -f4 -d' '`
 zip_file_name="$plugin_slug.$build_version.zip"
 cd "$(dirname "$plugindir")"
 
-if [ -f "$plugindir/.zipignore" ]; then
+ignore_file="$plugindir/.zipignore"
+if [ -f "$ignore_file" ]; then
 	ignore_file="$plugindir/.zipignore"
 elif [ -f "$plugindir/.distignore" ]; then
-	ignore_file="$plugindir/.distignore"
+	# Ensure ignore file begins and ends with *
+	sed "s/^[^*]/*&/g" "$plugindir/.distignore" | sed "s/[^*]$/&*/g" > "$ignore_file"
 else
 	echo "Error: please add a .zipignore to the root of the plugin"
 	exit 1

--- a/zip.sh
+++ b/zip.sh
@@ -13,12 +13,12 @@ ignore_file="$plugindir/.zipignore"
 if [ -f "$ignore_file" ]; then
 	ignore_file="$plugindir/.zipignore"
 elif [ -f "$plugindir/.distignore" ]; then
-	# Ensure ignore file begins and ends with *
-	sed "s/^[^*]/*&/g" "$plugindir/.distignore" | sed "s/[^*]$/&*/g" > "$ignore_file"
+	ignore_file="$plugindir/.distignore"
 else
 	echo "Error: please add a .zipignore to the root of the plugin"
 	exit 1
 fi
 
-zip -r "$zip_file_name" "$plugin_slug" -x@"$ignore_file"
+# Ensure ignore file begins and ends with *
+sed "s/^[^*]/*&/g" "$ignore_file" | sed "s/[^*]$/&*/g" | xargs zip -r "$zip_file_name" "$plugin_slug" -x
 mv "$zip_file_name" "$plugindir"

--- a/zip.sh
+++ b/zip.sh
@@ -9,7 +9,7 @@ build_version=`grep 'Version:' "$plugindir"/$plugin_slug.php | cut -f4 -d' '`
 zip_file_name="$plugin_slug.$build_version.zip"
 cd "$(dirname "$plugindir")"
 
-if [ -f "$ignore_file" ]; then
+if [ -f "$plugindir/.zipignore" ]; then
 	ignore_file="$plugindir/.zipignore"
 elif [ -f "$plugindir/.distignore" ]; then
 	ignore_file="$plugindir/.distignore"

--- a/zip.sh
+++ b/zip.sh
@@ -9,7 +9,6 @@ build_version=`grep 'Version:' "$plugindir"/$plugin_slug.php | cut -f4 -d' '`
 zip_file_name="$plugin_slug.$build_version.zip"
 cd "$(dirname "$plugindir")"
 
-ignore_file="$plugindir/.zipignore"
 if [ -f "$ignore_file" ]; then
 	ignore_file="$plugindir/.zipignore"
 elif [ -f "$plugindir/.distignore" ]; then

--- a/zip.sh
+++ b/zip.sh
@@ -18,6 +18,6 @@ else
 	exit 1
 fi
 
-# Ensure ignore file begins and ends with *
+# Ensure every line in the ignore file begins and ends with *
 sed "s/^[^*]/*&/g" "$ignore_file" | sed "s/[^*]$/&*/g" | xargs zip -r "$zip_file_name" "$plugin_slug" -x
 mv "$zip_file_name" "$plugindir"


### PR DESCRIPTION
* This lets us keep the PM repo cleaner. We won't need both a `.zipignore` and `.svnignore`, just a `.distignore`.
* A zip ignore file has to begin and end every line with a `*`, though a `.distignore` file also used as an svn ignore file won't have that format
* So this ensures every line begins and ends with `*`
* Won't alter the file, it passes the changed file right to the `zip` command, without writing to the file

This PR is running in https://github.com/studiopress/pattern-manager/pull/108