### PR TITLE
[Do Not Merge] Handle react-test-renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
 		"@wordpress/env": "^4.3.1",
 		"@wordpress/eslint-plugin": "^12.4.0",
 		"@wordpress/jest-preset-default": "^8.1.1",
-		"@wordpress/scripts": "24.0.0"
+		"@wordpress/scripts": "24.0.0",
+		"@testing-library/react": "^14.0.0",
+		"react-test-renderer": "^17.0.2",
+		"@types/jest": "^29.4.0",
+		"@types/react-test-renderer": "^17.0.2"
 	}
 }

--- a/setup.sh
+++ b/setup.sh
@@ -9,6 +9,8 @@ while getopts 'p:n:t:f:' flag; do
 	esac
 done
 
+wpps_scripts_dir="$PWD";
+
 plugindirname=$(basename "$plugindir")
 
 # Make sure the node version matches.

--- a/test-js.sh
+++ b/test-js.sh
@@ -17,6 +17,7 @@ for DIR in "$plugindir"/wp-modules/*; do
 			cp -r "$wpps_scripts_dir"/node_modules/react-test-renderer "$DIR"/node_modules/react-test-renderer
 			cp -r "$wpps_scripts_dir"/node_modules/@types/jest "$DIR"/node_modules/@types/jest
 			cp -r "$wpps_scripts_dir"/node_modules/@types/react-test-renderer "$DIR"/node_modules/@types/react-test-renderer
+			cp -r "$wpps_scripts_dir"/node_modules/@testing-library/react "$DIR"/node_modules/@testing-library/react
 		fi
 		
 		cd - > /dev/null

--- a/test-js.sh
+++ b/test-js.sh
@@ -15,9 +15,14 @@ for DIR in "$plugindir"/wp-modules/*; do
 			# Move copies of node_modules required to run tests with react-test-renderer to each wp-modules node_modules directory.
 			# This allows wp-modules to keep testing dependencies out of their package.json files, and instead rely on wpps-scripts to handle that.
 			cp -r "$wpps_scripts_dir"/node_modules/react-test-renderer "$DIR"/node_modules/react-test-renderer
+			
+			mkdir -p "$DIR"/node_modules/@types
 			cp -r "$wpps_scripts_dir"/node_modules/@types/jest "$DIR"/node_modules/@types/jest
 			cp -r "$wpps_scripts_dir"/node_modules/@types/react-test-renderer "$DIR"/node_modules/@types/react-test-renderer
+			
+			mkdir -p "$DIR"/node_modules/@testing-library
 			cp -r "$wpps_scripts_dir"/node_modules/@testing-library/react "$DIR"/node_modules/@testing-library/react
+			cp -r "$wpps_scripts_dir"/node_modules/@testing-library/dom "$DIR"/node_modules/@testing-library/dom
 		fi
 		
 		cd - > /dev/null

--- a/test-js.sh
+++ b/test-js.sh
@@ -14,15 +14,18 @@ for DIR in "$plugindir"/wp-modules/*; do
 		if [ -d node_modules ]; then
 			# Move copies of node_modules required to run tests with react-test-renderer to each wp-modules node_modules directory.
 			# This allows wp-modules to keep testing dependencies out of their package.json files, and instead rely on wpps-scripts to handle that.
+			
+			# Copy react-test-renderer
 			cp -r "$wpps_scripts_dir"/node_modules/react-test-renderer "$DIR"/node_modules/react-test-renderer
 			
+			# Copy @types modules
 			mkdir -p "$DIR"/node_modules/@types
 			cp -r "$wpps_scripts_dir"/node_modules/@types/jest "$DIR"/node_modules/@types/jest
 			cp -r "$wpps_scripts_dir"/node_modules/@types/react-test-renderer "$DIR"/node_modules/@types/react-test-renderer
 			
+			# Copy @testing-library module
 			mkdir -p "$DIR"/node_modules/@testing-library
-			cp -r "$wpps_scripts_dir"/node_modules/@testing-library/react "$DIR"/node_modules/@testing-library/react
-			cp -r "$wpps_scripts_dir"/node_modules/@testing-library/dom "$DIR"/node_modules/@testing-library/dom
+			cp -r "$wpps_scripts_dir"/node_modules/@testing-library "$DIR"/node_modules/@testing-library
 		fi
 		
 		cd - > /dev/null

--- a/test-js.sh
+++ b/test-js.sh
@@ -3,4 +3,24 @@
 # Run setup.
 . ./setup.sh
 
+# Loop through each wp-module in the plugin.
+for DIR in "$plugindir"/wp-modules/*; do
+	# If this module has a package.json file.
+	if [ -f "$DIR"/package.json ]; then
+		# Go to the directory of this wp-module.
+		cd "$DIR";
+
+		# If a node_modules directory exists.
+		if [ -d node_modules ]; then
+			# Move copies of node_modules required to run tests with react-test-renderer to each wp-modules node_modules directory.
+			# This allows wp-modules to keep testing dependencies out of their package.json files, and instead rely on wpps-scripts to handle that.
+			cp -r "$wpps_scripts_dir"/node_modules/react-test-renderer "$DIR"/node_modules/react-test-renderer
+			cp -r "$wpps_scripts_dir"/node_modules/@types/jest "$DIR"/node_modules/@types/jest
+			cp -r "$wpps_scripts_dir"/node_modules/@types/react-test-renderer "$DIR"/node_modules/@types/react-test-renderer
+		fi
+		
+		cd - > /dev/null
+	fi
+done
+
 npm run test:js -- --roots "$plugindir"


### PR DESCRIPTION
This PR makes wpps-scripts able to handle all of the dependencies required for running tests with `react-test-renderer`. 

That means any plugin using wpps-scripts can remove `react-test-renderer` as a dependency in it's package.json files, but the tests will still run.