### PR TITLE
Fix php since wp-env changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 /phpcs.xml
 /.wp-env.json
 /.wp-env.json.bak
+.phpunit.result.cache

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"test:js": "wp-scripts test-unit-js"
 	},
 	"devDependencies": {
-		"@wordpress/env": "^4.3.1",
+		"@wordpress/env": "^7.0.0",
 		"@wordpress/eslint-plugin": "^12.4.0",
 		"@wordpress/jest-preset-default": "^8.1.1",
 		"@wordpress/scripts": "24.0.0"

--- a/phpunit.sh
+++ b/phpunit.sh
@@ -14,8 +14,5 @@ sed -i.bak "s/REPLACE_WITH_PLUGIN_DIR_NAME/$plugindirname/g" .wp-env.json
 npx -p @wordpress/env wp-env start
 
 # Run PHPunit inside wp-env, targeting the plugin in question.
-if [ "$multisite" = "1" ]; then
-	npx -p @wordpress/env wp-env run phpunit "WP_MULTISITE=1 phpunit -c /var/www/html/wp-content/wpps-scripts/phpunit.xml.dist /var/www/html/wp-content/plugins/$plugindirname"
-else
-	npx -p @wordpress/env wp-env run phpunit "phpunit -c /var/www/html/wp-content/wpps-scripts/phpunit.xml.dist /var/www/html/wp-content/plugins/$plugindirname"
-fi
+npx -p @wordpress/env wp-env run --env-cwd=\"wp-content/wpps-scripts\" tests-wordpress phpunit -c ./phpunit.xml.dist /var/www/html/wp-content/plugins/$plugindirname
+


### PR DESCRIPTION
In the wp-env project (inside Gutenberg repo), the [PHPUnit and Composer packages were removed](https://github.com/WordPress/gutenberg/pull/50408). 

This resulted in PHPunit tests failing to run using wpp-scripts with the message:
`The 'phpunit' container has been removed. Please use 'wp-env run tests-cli --env-cwd=wp-content/path/to/plugin phpunit' instead.`

### Note:
This PR changes that over. I haven't had a chance to figure out how to get multisite to work yet, so I have removed that for now.

This may require changes to a few things in your tests suite. See [companion PR in pattern-manager](https://github.com/studiopress/pattern-manager/pull/182) for more details on changes required there.