### PR TITLE
Fix php unit changes made in wp-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"test:js": "wp-scripts test-unit-js"
 	},
 	"devDependencies": {
-		"@wordpress/env": "^7.0.0",
+		"@wordpress/env": "^8.0.0",
 		"@wordpress/eslint-plugin": "^12.4.0",
 		"@wordpress/jest-preset-default": "^8.1.1",
 		"@wordpress/scripts": "24.0.0"

--- a/phpunit.sh
+++ b/phpunit.sh
@@ -14,5 +14,5 @@ sed -i.bak "s/REPLACE_WITH_PLUGIN_DIR_NAME/$plugindirname/g" .wp-env.json
 npx -p @wordpress/env wp-env start
 
 # Run PHPunit inside wp-env, targeting the plugin in question.
-npx -p @wordpress/env wp-env run --env-cwd=\"wp-content/wpps-scripts\" tests-wordpress phpunit -c ./phpunit.xml.dist /var/www/html/wp-content/plugins/$plugindirname
+npx -p @wordpress/env wp-env run --env-cwd='wp-content/wpps-scripts' tests-wordpress vendor/bin/phpunit -c ./phpunit.xml.dist /var/www/html/wp-content/plugins/$plugindirname
 


### PR DESCRIPTION
Changes in the wp-env package have broken PHPunit again. To fix it this PR is required.

This fix will fix it for all plugins using wpps-scripts without requiring changes in the plugins themselves.

