### PR TITLE
Add an install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Run phpunit, eslint, and stylelint using WordPress Coding Standards for any Word
 	"scripts": {
 		"preinstall": "if [ ! -d ../../wpps-scripts ]; then git clone https://github.com/wp-plugin-sidekick/wpps-scripts ../../wpps-scripts; else cd ../../wpps-scripts && git reset --hard && git checkout main && git pull origin main;fi;",
 		"postinstall": "cd ../../wpps-scripts; sh install.sh $npm_package_wpps_options -p \"${OLDPWD}\";",
+		"reinstall": "cd ../../wpps-scripts; sh install-clean.sh $npm_package_wpps_options -p \"${OLDPWD}\";",
 		"dev": "cd ../../wpps-scripts; sh dev.sh $npm_package_wpps_options -p \"${OLDPWD}\";",
 		"build": "cd ../../wpps-scripts; sh build.sh $npm_package_wpps_options -p \"${OLDPWD}\";",
 		"test:phpunit": "cd ../../wpps-scripts; sh phpunit.sh $npm_package_wpps_options -p \"${OLDPWD}\";",

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Run phpunit, eslint, and stylelint using WordPress Coding Standards for any Word
 	"wpps_options": "-n YourPluginNamespace -t your-plugin-textdomain",
 	"scripts": {
 		"preinstall": "if [ ! -d ../../wpps-scripts ]; then git clone https://github.com/wp-plugin-sidekick/wpps-scripts ../../wpps-scripts; else cd ../../wpps-scripts && git reset --hard && git checkout main && git pull origin main;fi;",
+		"postinstall": "cd ../../wpps-scripts; sh install.sh $npm_package_wpps_options -p \"${OLDPWD}\";",
 		"dev": "cd ../../wpps-scripts; sh dev.sh $npm_package_wpps_options -p \"${OLDPWD}\";",
 		"build": "cd ../../wpps-scripts; sh build.sh $npm_package_wpps_options -p \"${OLDPWD}\";",
 		"test:phpunit": "cd ../../wpps-scripts; sh phpunit.sh $npm_package_wpps_options -p \"${OLDPWD}\";",

--- a/install-clean.sh
+++ b/install-clean.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Run setup.
+. ./setup.sh
+
+# Loop through each wp-module in the plugin.
+for DIR in "$plugindir"/wp-modules/*; do
+	# If this module has a package.json file.
+	if [ -f "$DIR/package.json" ];
+	then
+		# Go to the directory of this wp-module.
+		cd "$DIR";
+		# Run npm install for this module.
+		npm ci;
+	fi
+
+done
+
+# Finish with a wait command, which lets a kill (cmd+c) kill all of the process created in this loop.
+wait;

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Run setup.
+. ./setup.sh
+
+# Loop through each wp-module in the plugin.
+for DIR in "$plugindir"/wp-modules/*; do
+	# If this module has a package.json file.
+	if [ -f "$DIR/package.json" ];
+	then
+		# Go to the directory of this wp-module.
+		cd "$DIR";
+		# Run npm install for this module.
+		npm install;
+	fi
+
+done
+
+# Finish with a wait command, which lets a kill (cmd+c) kill all of the process created in this loop.
+wait;


### PR DESCRIPTION
Right now, there are scripts for programmatically running `dev` and `build` for `wp-modules` packages without needing to `cd` into those directories. This PR adds an `install` script that does the same for initially installing dependencies for `wp-modules` packages.

This means you could start a project using `wpps-scripts` by simply pulling down the repo and running `npm install` in only the root folder.

An option for clean install is also included.